### PR TITLE
Fix: Resume header dinamic growth

### DIFF
--- a/app/styles/layouts/_page.scss
+++ b/app/styles/layouts/_page.scss
@@ -11,6 +11,9 @@
   @include clearfix();
   .resume-header {
     background-color: $gray-light;
+    display: flex;
+    min-height: $header-height;
+    
     .background-header {
       &.background-employee,
       &.background-dev {
@@ -18,11 +21,14 @@
         background-size: cover;
         .profile-header {
           color: $white;
+
+          &.pull-right {
+            padding: 0.5em 0;
+          }
           .my-auto {
             text-align: left;
           }
           .ksquare-image {
-            background-image: url($ksquare-image);
             background-repeat: no-repeat;
             background-size: contain;
             display: block;
@@ -30,24 +36,28 @@
           }
         }
       }
+
     }
+
     .background-employee {
       background-image: url($background-employee-image);
+      border-bottom: 0.6em solid $dark-blue;
+      .ksquare-image {
+        background-image: url($ksquare-logo-blue);
+      }
     }
+
     .background-dev {
       background-image: url($background-dev-image);
-    }
-    &.resume-header-dev {
       border-bottom: 0.6em solid $blue-ksquare;
+      .ksquare-image {
+        background-image: url($ksquare-logo-white);
+      }
     }
-    &.resume-header-employee {
-      border-bottom: 0.6em solid $dark-blue;
-    }
-
-    height: $header-height;
 
     .background-header {
-      height: $header-height + 0.1em;
+      align-items: center;
+      display: flex;
       position: relative;
       width: $page-width;
 

--- a/app/styles/utils/_variables.scss
+++ b/app/styles/utils/_variables.scss
@@ -36,7 +36,7 @@ $print-width: 22cm;
 $print-height: 29.7cm;
 $page-width: 100%;
 $page-height: 60em;
-$header-height: 10.7em;
+$header-height: 11.2em;
 
 $mobile-width: 435px;
 $tablet-width: 768px;
@@ -50,8 +50,8 @@ $aside-width: 160px;
 $aside-margin: 20px;
 $pad-unit: 0.3em;
 
-$ksquare-image: "https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/ks-logo-white.png";
+$ksquare-logo-blue: 'https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/ks-logo-blue%402x.png';
+$ksquare-logo-white: "https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/ks-logo-white%402x.png";
 
 $background-employee-image: "https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/FondoBranding1%403x.png";
-
 $background-dev-image: "https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/FondoBranding2%403x.png";

--- a/app/views/components/resume-header.hbs
+++ b/app/views/components/resume-header.hbs
@@ -1,5 +1,5 @@
 {{#resume.basics}}
-<header class="resume-header clearfix {{~#if branding}} {{#isDev label }} resume-header-dev {{else}} resume-header-employee {{/isDev}} {{~/if~}}">
+<header class="resume-header clearfix ">
   <div class="background-header {{~#if branding}} {{#isDev label }} background-dev {{else}} background-employee {{/isDev}} {{~/if~}} ">
     <div class="profile-pic {{#centerHeader branding image}} d-none {{/centerHeader}} pull-left">
       {{#if image}}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Abelardo Ramírez",
   "name": "jsonresume-theme-ks",
   "description": "Theme for ksquare employees with JSON Resume",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "keywords": [
     "json",
     "resume",


### PR DESCRIPTION
### Type of PR
- [ ] Feature
- [X] Bugfix
- [ ] Hotfix
- [ ] Chore

### Merge strategy
- [X] Squash (default)
- [ ] Merge commit (branch merges, usually used for merges to master)
- [ ] Rebase (preserve individual commits without merge commit)

### Purpose

> The header now has a minimum height and dynamically grows based on its content preventing any information to be cut-off due overflow.
> Updated the KSquare logo for employee banner because it wasn't show correctly due to color overlapping.

### Relevant tickets
- Bug Report [#20](https://theksquaregroup.openproject.com/projects/ksgksq-employee-portal/work_packages/16025/activity?query_props=%7B%22c%22%3A%5B%22id%22%2C%22subject%22%2C%22type%22%2C%22status%22%2C%22author%22%2C%22updatedAt%22%5D%2C%22hi%22%3Afalse%2C%22g%22%3A%22%22%2C%22t%22%3A%22updatedAt%3Adesc%2Cid%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22status%22%2C%22o%22%3A%22o%22%2C%22v%22%3A%5B%5D%7D%2C%7B%22n%22%3A%22assigneeOrGroup%22%2C%22o%22%3A%22%3D%22%2C%22v%22%3A%5B%22me%22%5D%7D%5D%7D)

### Screenshots
> Before (website info cut-off and unnoticeable logo)
![image](https://user-images.githubusercontent.com/90219969/163858403-bb659ff1-73ff-4127-8d64-1bec89d6d760.png)

> After (header size adjust and logo now is noticeable)
![image](https://user-images.githubusercontent.com/90219969/163858663-21a2e90b-cb3c-4774-b192-49dba5f00370.png)



