### PR TITLE
fix: banners displayed correctly when exporting pdf

### DIFF
--- a/app/styles/base/_global.scss
+++ b/app/styles/base/_global.scss
@@ -1,3 +1,10 @@
+.align-items-center {
+  -webkit-flex-align: center;
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  align-items: center;
+}
+
 .container {
   padding-bottom: spacing(4);
 }

--- a/app/styles/layouts/_page.scss
+++ b/app/styles/layouts/_page.scss
@@ -11,7 +11,7 @@
   @include clearfix();
   .resume-header {
     background-color: $gray-light;
-    display: flex;
+    @extend .flex;
     min-height: $header-height;
     
     .background-header {
@@ -41,7 +41,6 @@
 
     .background-employee {
       background-image: url($background-employee-image);
-      border-bottom: 0.6em solid $dark-blue;
       .ksquare-image {
         background-image: url($ksquare-logo-blue);
       }
@@ -49,15 +48,21 @@
 
     .background-dev {
       background-image: url($background-dev-image);
-      border-bottom: 0.6em solid $blue-ksquare;
       .ksquare-image {
         background-image: url($ksquare-logo-white);
       }
     }
 
+    &.resume-header-dev {
+      border-bottom: 0.6em solid $blue-ksquare;
+    }
+    &.resume-header-employee {
+      border-bottom: 0.6em solid $dark-blue;
+    }
+
     .background-header {
-      align-items: center;
-      display: flex;
+      @extend .align-items-center;
+      @extend .flex;
       position: relative;
       width: $page-width;
 

--- a/app/views/components/resume-header.hbs
+++ b/app/views/components/resume-header.hbs
@@ -1,5 +1,5 @@
 {{#resume.basics}}
-<header class="resume-header clearfix ">
+<header class="resume-header clearfix {{~#if branding}} {{#isDev label }} resume-header-dev {{else}} resume-header-employee {{/isDev}} {{~/if~}}">
   <div class="background-header {{~#if branding}} {{#isDev label }} background-dev {{else}} background-employee {{/isDev}} {{~/if~}} ">
     <div class="profile-pic {{#centerHeader branding image}} d-none {{/centerHeader}} pull-left">
       {{#if image}}

--- a/public/index.html
+++ b/public/index.html
@@ -176,6 +176,12 @@ body {
 @page {
   size: A4; }
 
+.align-items-center, .page .resume-header .background-header {
+  -webkit-flex-align: center;
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  align-items: center; }
+
 .container {
   padding-bottom: 1.2em; }
 
@@ -194,7 +200,7 @@ body {
   display: table;
   clear: both; }
 
-.flex, .profile-pic, .page, .page .resume-header .background-header .profile-header, .page .resume-content, .page .resume-footer {
+.flex, .profile-pic, .page, .page .resume-header, .page .resume-header .background-header, .page .resume-header .background-header .profile-header, .page .resume-content, .page .resume-footer {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -247,7 +253,6 @@ body {
     clear: both; }
   .page .resume-header {
     background-color: #f2f2f2;
-    display: flex;
     min-height: 11.2em; }
     .page .resume-header .background-header.background-employee, .page .resume-header .background-header.background-dev {
       background-repeat: no-repeat;
@@ -264,18 +269,18 @@ body {
           display: block;
           height: 2em; }
     .page .resume-header .background-employee {
-      background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/FondoBranding1%403x.png");
-      border-bottom: 0.6em solid #1e326b; }
+      background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/FondoBranding1%403x.png"); }
       .page .resume-header .background-employee .ksquare-image {
         background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/ks-logo-blue%402x.png"); }
     .page .resume-header .background-dev {
-      background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/FondoBranding2%403x.png");
-      border-bottom: 0.6em solid #46a0b6; }
+      background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/FondoBranding2%403x.png"); }
       .page .resume-header .background-dev .ksquare-image {
         background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/ks-logo-white%402x.png"); }
+    .page .resume-header.resume-header-dev {
+      border-bottom: 0.6em solid #46a0b6; }
+    .page .resume-header.resume-header-employee {
+      border-bottom: 0.6em solid #1e326b; }
     .page .resume-header .background-header {
-      align-items: center;
-      display: flex;
       position: relative;
       width: 100%; }
       .page .resume-header .background-header .profile-header {
@@ -404,7 +409,7 @@ body {
 
 <body>
   <main id="resume" class="page">
-    <header class="resume-header clearfix ">
+    <header class="resume-header clearfix  resume-header-employee ">
       <div class="background-header  background-employee ">
         <div class="profile-pic  pull-left">
             {{#basics.image}}<img src='{{basics.image}}' alt='profile-pic'/>{{/basics.image}}

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -168,6 +168,12 @@ body {
 @page {
   size: A4; }
 
+.align-items-center, .page .resume-header .background-header {
+  -webkit-flex-align: center;
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  align-items: center; }
+
 .container {
   padding-bottom: 1.2em; }
 
@@ -186,7 +192,7 @@ body {
   display: table;
   clear: both; }
 
-.flex, .profile-pic, .page, .page .resume-header .background-header .profile-header, .page .resume-content, .page .resume-footer {
+.flex, .profile-pic, .page, .page .resume-header, .page .resume-header .background-header, .page .resume-header .background-header .profile-header, .page .resume-content, .page .resume-footer {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -239,7 +245,6 @@ body {
     clear: both; }
   .page .resume-header {
     background-color: #f2f2f2;
-    display: flex;
     min-height: 11.2em; }
     .page .resume-header .background-header.background-employee, .page .resume-header .background-header.background-dev {
       background-repeat: no-repeat;
@@ -256,18 +261,18 @@ body {
           display: block;
           height: 2em; }
     .page .resume-header .background-employee {
-      background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/FondoBranding1%403x.png");
-      border-bottom: 0.6em solid #1e326b; }
+      background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/FondoBranding1%403x.png"); }
       .page .resume-header .background-employee .ksquare-image {
         background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/ks-logo-blue%402x.png"); }
     .page .resume-header .background-dev {
-      background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/FondoBranding2%403x.png");
-      border-bottom: 0.6em solid #46a0b6; }
+      background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/FondoBranding2%403x.png"); }
       .page .resume-header .background-dev .ksquare-image {
         background-image: url("https://dev-kportalapp-frontend-bucket.s3.us-east-2.amazonaws.com/resumes-templates/ks-logo-white%402x.png"); }
+    .page .resume-header.resume-header-dev {
+      border-bottom: 0.6em solid #46a0b6; }
+    .page .resume-header.resume-header-employee {
+      border-bottom: 0.6em solid #1e326b; }
     .page .resume-header .background-header {
-      align-items: center;
-      display: flex;
       position: relative;
       width: 100%; }
       .page .resume-header .background-header .profile-header {

--- a/public/views/components/resume-header.hbs
+++ b/public/views/components/resume-header.hbs
@@ -1,5 +1,5 @@
 {{#resume.basics}}
-<header class="resume-header clearfix ">
+<header class="resume-header clearfix {{~#if branding}} {{#isDev label }} resume-header-dev {{else}} resume-header-employee {{/isDev}} {{~/if~}}">
   <div class="background-header {{~#if branding}} {{#isDev label }} background-dev {{else}} background-employee {{/isDev}} {{~/if~}} ">
     <div class="profile-pic {{#centerHeader branding image}} d-none {{/centerHeader}} pull-left">
       {{#if image}}


### PR DESCRIPTION
### Type of PR
- [ ] Feature
- [X] Bugfix
- [ ] Hotfix
- [ ] Chore

### Merge strategy
- [X] Squash (default)
- [ ] Merge commit (branch merges, usually used for merges to master)
- [ ] Rebase (preserve individual commits without merge commit)

### Purpose

> The header now correctly loads the banner images when exporting to a .pdf file
